### PR TITLE
Fix test variable initialization order

### DIFF
--- a/test_templates/base.html
+++ b/test_templates/base.html
@@ -42,7 +42,7 @@
         testapi.reportStepResult(stepId, result, message);
         {% else %}
         console.log(`Step ${stepId}: ${result} - ${message}`);
-        const div = document.createElement("div");
+        const div = document.createElement('div');
         div.textContent = `Step ${stepId}: ${result} - ${message}`;
         div.className = result.toLowerCase();
         document.body.appendChild(div);
@@ -54,7 +54,7 @@
         testapi.endTest(result, message);
         {% else %}
         console.log(`Test ended: ${result} - ${message}`);
-        const div = document.createElement("div");
+        const div = document.createElement('div');
         div.textContent = `Test ended: ${result} - ${message}`;
         div.className = `test-end ${result.toLowerCase()}`;
         document.body.appendChild(div);

--- a/test_templates/base.html
+++ b/test_templates/base.html
@@ -7,6 +7,9 @@
     <script type="text/javascript" src="../../RES/testsuite.js"></script>
     {% endif %}
     <script>
+    // Initialize test variables
+    {{ test_init }}
+
     {% if target == "hbbtv" %}
     var testapi;
     window.onload = function() {
@@ -27,8 +30,6 @@
         console.log("Starting test {{ test_id }}");
         {% endif %}
         
-        {{ test_init }}
-        
         runTest();
     }
 
@@ -41,7 +42,7 @@
         testapi.reportStepResult(stepId, result, message);
         {% else %}
         console.log(`Step ${stepId}: ${result} - ${message}`);
-        const div = document.createElement('div');
+        const div = document.createElement("div");
         div.textContent = `Step ${stepId}: ${result} - ${message}`;
         div.className = result.toLowerCase();
         document.body.appendChild(div);
@@ -53,7 +54,7 @@
         testapi.endTest(result, message);
         {% else %}
         console.log(`Test ended: ${result} - ${message}`);
-        const div = document.createElement('div');
+        const div = document.createElement("div");
         div.textContent = `Test ended: ${result} - ${message}`;
         div.className = `test-end ${result.toLowerCase()}`;
         document.body.appendChild(div);


### PR DESCRIPTION
This PR fixes the test variable initialization issue by:

1. Moving test variable initialization before window.onload
2. Ensuring variables are available when test starts
3. Updating the base template to support this order

The fix has been tested and works in both:
- W3C browser version: https://jensk-dk.github.io/HtmlHbbTVTestCaseGenerator/test/TEST_001.html
- HbbTV test harness version

The test now correctly:
1. Initializes variables
2. Runs test steps
3. Reports results