### PR TITLE
Add support for manual test steps

### DIFF
--- a/test_templates/TEST_001_step_sequence/test.html
+++ b/test_templates/TEST_001_step_sequence/test.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8">
-    <title>Example Test Case</title>
     <script>
-    // Test metadata (used by generator)
+    // Test metadata
     var TEST_METADATA = {
         "test_id": "TEST_001",
         "test_name": "Example Test Case - Step Sequence",
@@ -13,27 +11,33 @@
 
     // Test initialization code
     var TEST_INIT = `
-        var testSteps = ['step1', 'step2', 'step3'];
+        var testSteps = ["step1", "step2", "step3"];
         var currentStep = 0;
     `;
 
     // Test execution code
     var TEST_BODY = `
-        function checkStep() {
+        async function checkStep() {
             switch(testSteps[currentStep]) {
-                case 'step1':
+                case "step1":
                     reportStep(1, "PASS", "First step completed");
                     currentStep++;
                     setTimeout(checkStep, 1000);
                     break;
                     
-                case 'step2':
-                    reportStep(2, "PASS", "Second step completed");
-                    currentStep++;
-                    setTimeout(checkStep, 1000);
+                case "step2":
+                    const manualResult = await askManual("Did you see the first step complete successfully?");
+                    if (manualResult) {
+                        reportStep(2, "PASS", "Manual verification successful");
+                        currentStep++;
+                        setTimeout(checkStep, 1000);
+                    } else {
+                        reportStep(2, "FAIL", "Manual verification failed");
+                        endTest("FAIL", "Manual verification failed at step 2");
+                    }
                     break;
                     
-                case 'step3':
+                case "step3":
                     reportStep(3, "PASS", "Third step completed");
                     endTest("PASS", "All steps completed successfully");
                     break;
@@ -45,9 +49,8 @@
     </script>
 </head>
 <body>
-    <!-- Optional: Add any HTML elements needed for the test -->
     <div id="test-container">
-        <p>This test verifies a sequence of steps with timing.</p>
+        <p>This test verifies a sequence of steps with timing and manual verification.</p>
     </div>
 </body>
 </html>

--- a/test_templates/base.html
+++ b/test_templates/base.html
@@ -37,6 +37,28 @@
         {{ test_body }}
     }
 
+    function askManual(question) {
+        return new Promise((resolve) => {
+            {% if target == "hbbtv" %}
+            testapi.analyzeManual(question, function(success) {
+                resolve(success);
+            });
+            {% else %}
+            const promptDiv = document.createElement('div');
+            promptDiv.className = 'manual-prompt';
+            promptDiv.innerHTML = `
+                <div class="question">${question}</div>
+                <div class="buttons">
+                    <button onclick="this.parentElement.parentElement.remove(); window._manualResolve(true)">Yes</button>
+                    <button onclick="this.parentElement.parentElement.remove(); window._manualResolve(false)">No</button>
+                </div>
+            `;
+            document.body.appendChild(promptDiv);
+            window._manualResolve = resolve;
+            {% endif %}
+        });
+    }
+
     function reportStep(stepId, result, message) {
         {% if target == "hbbtv" %}
         testapi.reportStepResult(stepId, result, message);
@@ -68,6 +90,41 @@
     .test-end { 
         margin-top: 20px;
         font-weight: bold;
+    }
+    .manual-prompt {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: white;
+        border: 2px solid #333;
+        padding: 20px;
+        box-shadow: 0 0 10px rgba(0,0,0,0.5);
+        text-align: center;
+    }
+    .manual-prompt .question {
+        margin-bottom: 20px;
+        font-size: 16px;
+    }
+    .manual-prompt .buttons {
+        display: flex;
+        justify-content: center;
+        gap: 20px;
+    }
+    .manual-prompt button {
+        padding: 10px 20px;
+        font-size: 14px;
+        cursor: pointer;
+    }
+    .manual-prompt button:first-child {
+        background: #4CAF50;
+        color: white;
+        border: none;
+    }
+    .manual-prompt button:last-child {
+        background: #f44336;
+        color: white;
+        border: none;
     }
     {% endif %}
     {{ additional_styles }}


### PR DESCRIPTION
This PR adds support for manual test steps:

1. New `askManual` function that returns a Promise:
   - Uses `analyzeManual` for HbbTV
   - Shows Yes/No buttons for W3C browsers

2. Updated example test case:
   - Step 1: Automatic pass
   - Step 2: Manual verification
   - Step 3: Automatic pass

3. Added CSS styling for manual prompts in W3C version:
   - Centered modal dialog
   - Green Yes button
   - Red No button

The changes allow test cases to include steps that require operator verification.