### PR TITLE
Add GitLab CI and Playwright tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 tests/
 tests/HbbTV/
 tests/Html/
+!tests/test_w3c.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+image: mcr.microsoft.com/playwright:v1.40.0-jammy
+
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.pip-cache"
+
+cache:
+  paths:
+    - .pip-cache/
+    - .pytest_cache/
+    - node_modules/
+
+stages:
+  - setup
+  - test
+  - deploy
+
+install-dependencies:
+  stage: setup
+  script:
+    - pip install jinja2 beautifulsoup4 pytest pytest-playwright
+    - playwright install chromium
+  artifacts:
+    paths:
+      - .pip-cache/
+    expire_in: 1 week
+
+test-generator:
+  stage: test
+  script:
+    - python test_generator.py
+    - test -f tests/Html/TEST_001/index.html || (echo "W3C test file not generated" && exit 1)
+    - test -f tests/HbbTV/TEST_001/index.html || (echo "HbbTV test file not generated" && exit 1)
+    - test -f tests/HbbTV/TEST_001/implementation.xml || (echo "HbbTV implementation.xml not generated" && exit 1)
+    - test -f tests/HbbTV/TEST_001/ait.xml || (echo "HbbTV ait.xml not generated" && exit 1)
+    - test -f tests/HbbTV/TEST_001/playoutset.xml || (echo "HbbTV playoutset.xml not generated" && exit 1)
+
+test-w3c-browser:
+  stage: test
+  script:
+    - python test_generator.py
+    - pytest tests/test_w3c.py --browser chromium --headed
+  artifacts:
+    when: on_failure
+    paths:
+      - test-results/
+    expire_in: 1 week
+
+pages:
+  stage: deploy
+  script:
+    - python test_generator.py
+    - mkdir -p public/test
+    - cp tests/Html/TEST_001/index.html public/test/TEST_001.html
+  artifacts:
+    paths:
+      - public
+  only:
+    - main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+jinja2>=3.1.2
+beautifulsoup4>=4.12.2
+pytest>=7.4.3
+pytest-playwright>=0.4.3

--- a/tests/test_w3c.py
+++ b/tests/test_w3c.py
@@ -1,0 +1,55 @@
+import pytest
+from playwright.sync_api import Page, expect
+import os
+
+def test_example_test_case(page: Page):
+    # Load the test case
+    page.goto(f"file://{os.path.abspath(\"tests/Html/TEST_001/index.html\")}")
+    
+    # Wait for first step to complete
+    first_step = page.get_by_text("Step 1: PASS - First step completed")
+    expect(first_step).to_be_visible(timeout=5000)
+    
+    # Wait for manual verification prompt
+    manual_prompt = page.get_by_text("Did you see the first step complete successfully?")
+    expect(manual_prompt).to_be_visible(timeout=5000)
+    
+    # Click Yes
+    yes_button = page.get_by_role("button", name="Yes")
+    yes_button.click()
+    
+    # Wait for second step to complete
+    second_step = page.get_by_text("Step 2: PASS - Manual verification successful")
+    expect(second_step).to_be_visible(timeout=5000)
+    
+    # Wait for third step to complete
+    third_step = page.get_by_text("Step 3: PASS - Third step completed")
+    expect(third_step).to_be_visible(timeout=5000)
+    
+    # Wait for test completion
+    test_end = page.get_by_text("Test ended: PASS - All steps completed successfully")
+    expect(test_end).to_be_visible(timeout=5000)
+
+def test_example_test_case_manual_fail(page: Page):
+    # Load the test case
+    page.goto(f"file://{os.path.abspath(\"tests/Html/TEST_001/index.html\")}")
+    
+    # Wait for first step to complete
+    first_step = page.get_by_text("Step 1: PASS - First step completed")
+    expect(first_step).to_be_visible(timeout=5000)
+    
+    # Wait for manual verification prompt
+    manual_prompt = page.get_by_text("Did you see the first step complete successfully?")
+    expect(manual_prompt).to_be_visible(timeout=5000)
+    
+    # Click No
+    no_button = page.get_by_role("button", name="No")
+    no_button.click()
+    
+    # Wait for failure message
+    fail_step = page.get_by_text("Step 2: FAIL - Manual verification failed")
+    expect(fail_step).to_be_visible(timeout=5000)
+    
+    # Wait for test completion
+    test_end = page.get_by_text("Test ended: FAIL - Manual verification failed at step 2")
+    expect(test_end).to_be_visible(timeout=5000)


### PR DESCRIPTION
This PR adds CI/CD and automated testing:

1. GitLab CI configuration:
   - Install dependencies
   - Test generator output
   - Run Playwright tests
   - Deploy to Pages

2. Playwright tests:
   - Test successful path
   - Test manual verification failure
   - Verify all steps and messages

3. Requirements file:
   - Added dependencies for testing

The CI pipeline ensures:
- Generator works correctly
- W3C test cases run as expected
- Manual verification works in both success and failure cases