### PR TITLE
Refactor to support multiple base templates

### DIFF
--- a/templates/base/cards.html
+++ b/templates/base/cards.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ test_id }} - {{ test_name }}</title>
+    {% if target == "hbbtv" %}
+    <script type="text/javascript" src="../../RES/testsuite.js"></script>
+    {% endif %}
+    <script>
+    // Initialize test variables
+    {{ test_init }}
+
+    {% if target == "hbbtv" %}
+    var testapi;
+    window.onload = function() {
+        testapi = new HbbTVTestAPI();
+        testapi.init();
+        startTest();
+    };
+    {% else %}
+    window.onload = function() {
+        startTest();
+    };
+    {% endif %}
+
+    function startTest() {
+        {% if target == "hbbtv" %}
+        testapi.reportMessage("Starting test {{ test_id }}");
+        {% else %}
+        console.log("Starting test {{ test_id }}");
+        {% endif %}
+        
+        runTest();
+    }
+
+    function runTest() {
+        {{ test_body }}
+    }
+
+    function askManual(question) {
+        return new Promise((resolve) => {
+            const overlay = document.createElement('div');
+            overlay.className = 'overlay';
+            document.body.appendChild(overlay);
+
+            const promptDiv = document.createElement('div');
+            promptDiv.className = 'manual-prompt';
+            promptDiv.innerHTML = `
+                <div class="question">${question}</div>
+                <div class="buttons">
+                    <button onclick="this.closest('.manual-prompt').remove(); document.querySelector('.overlay').remove(); window._manualResolve(true)">Yes</button>
+                    <button onclick="this.closest('.manual-prompt').remove(); document.querySelector('.overlay').remove(); window._manualResolve(false)">No</button>
+                </div>
+            `;
+            document.body.appendChild(promptDiv);
+            window._manualResolve = resolve;
+        });
+    }
+
+    function reportStep(stepId, result, message) {
+        {% if target == "hbbtv" %}
+        testapi.reportStepResult(stepId, result, message);
+        {% else %}
+        console.log(`Step ${stepId}: ${result} - ${message}`);
+        const div = document.createElement('div');
+        div.textContent = `Step ${stepId}: ${result} - ${message}`;
+        div.className = result.toLowerCase();
+        document.getElementById('test-output').appendChild(div);
+        {% endif %}
+    }
+
+    function endTest(result, message) {
+        {% if target == "hbbtv" %}
+        testapi.endTest(result, message);
+        {% else %}
+        console.log(`Test ended: ${result} - ${message}`);
+        const div = document.createElement('div');
+        div.textContent = `Test ended: ${result} - ${message}`;
+        div.className = `test-end ${result.toLowerCase()}`;
+        document.getElementById('test-output').appendChild(div);
+        {% endif %}
+    }
+    </script>
+    <style>
+    :root {
+        --card-width: min(400px, calc(100vw - 40px));
+        --card-gap: 20px;
+    }
+
+    body {
+        margin: 0;
+        padding: var(--card-gap);
+        font-family: Arial, sans-serif;
+        background: #f0f0f0;
+        min-height: 100vh;
+        box-sizing: border-box;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--card-gap);
+        align-items: flex-start;
+        justify-content: center;
+    }
+
+    .card {
+        width: var(--card-width);
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        padding: 20px;
+        box-sizing: border-box;
+        max-height: calc(100vh - 2 * var(--card-gap));
+        overflow: auto;
+    }
+
+    #metadata-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    #metadata-card img {
+        max-width: min(200px, calc(var(--card-width) - 40px));
+        height: auto;
+        margin-bottom: 20px;
+    }
+
+    #metadata-card h1 {
+        margin: 0;
+        font-size: 1.5em;
+        color: #333;
+    }
+
+    #test-elements {
+        font-size: 1em;
+        line-height: 1.5;
+    }
+
+    .pass { color: green; }
+    .fail { color: red; }
+    .test-end { 
+        margin-top: 20px;
+        font-weight: bold;
+    }
+
+    .manual-prompt {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        text-align: center;
+        z-index: 1000;
+        max-width: var(--card-width);
+        width: 90%;
+    }
+
+    .manual-prompt .question {
+        margin-bottom: 20px;
+        font-size: 16px;
+    }
+
+    .manual-prompt .buttons {
+        display: flex;
+        justify-content: center;
+        gap: 20px;
+    }
+
+    .manual-prompt button {
+        padding: 10px 20px;
+        font-size: 14px;
+        cursor: pointer;
+        border: none;
+        border-radius: 4px;
+        transition: opacity 0.2s;
+    }
+
+    .manual-prompt button:hover {
+        opacity: 0.9;
+    }
+
+    .manual-prompt button:first-child {
+        background: #4CAF50;
+        color: white;
+    }
+
+    .manual-prompt button:last-child {
+        background: #f44336;
+        color: white;
+    }
+
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 999;
+    }
+
+    {{ additional_styles }}
+    </style>
+</head>
+<body>
+    <div id="metadata-card" class="card">
+        <img src="../../RES/logo.png" alt="Logo">
+        <h1>{{ test_name }}</h1>
+        <p>Test ID: {{ test_id }}</p>
+    </div>
+    <div id="test-elements" class="card">
+        {{ test_html }}
+    </div>
+    <div id="test-output" class="card">
+        <h2>Test Output</h2>
+    </div>
+</body>
+</html>

--- a/templates/base/grid.html
+++ b/templates/base/grid.html
@@ -88,33 +88,50 @@
         margin: 0;
         padding: 0;
         display: grid;
-        grid-template-columns: 50% 50%;
-        grid-template-rows: 50vh 50vh;
+        grid-template-columns: minmax(300px, 1fr) minmax(300px, 1fr);
+        grid-template-rows: minmax(200px, 45vh) minmax(200px, 45vh);
         min-height: 100vh;
+        max-height: 100vh;
+        overflow: hidden;
+        gap: 1vh;
     }
     
     #logo-metadata {
         grid-column: 1;
         grid-row: 1;
         padding: 20px;
-        border-right: 1px solid #ccc;
-        border-bottom: 1px solid #ccc;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         overflow: auto;
+        margin: 10px;
     }
     
     #test-elements {
         grid-column: 1;
         grid-row: 2;
         padding: 20px;
-        border-right: 1px solid #ccc;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         overflow: auto;
+        margin: 10px;
     }
     
     #test-output {
         grid-column: 2;
         grid-row: 1 / span 2;
         padding: 20px;
+        background: white;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         overflow: auto;
+        margin: 10px;
+    }
+    
+    body {
+        background: #f0f0f0;
+        font-family: Arial, sans-serif;
     }
     
     {% if target == "w3c" %}

--- a/test_templates/TEST_001_step_sequence/test.json
+++ b/test_templates/TEST_001_step_sequence/test.json
@@ -1,0 +1,7 @@
+{
+    "name": "Basic Step Sequence Test",
+    "base_template": "grid.html",
+    "init": "var stepCount = 0;",
+    "body": "stepCount++;\\nif (stepCount === 1) {\\n    reportStep(stepCount, 'PASS', 'Automatic step completed');\\n    setTimeout(runTest, 1000);\\n} else if (stepCount === 2) {\\n    askManual('Did you see the previous step pass?').then(function(result) {\\n        reportStep(stepCount, result ? 'PASS' : 'FAIL', 'Manual verification ' + (result ? 'succeeded' : 'failed'));\\n        setTimeout(runTest, 1000);\\n    });\\n} else {\\n    askManual('Is everything working as expected?').then(function(result) {\\n        reportStep(stepCount, result ? 'PASS' : 'FAIL', 'Final verification ' + (result ? 'succeeded' : 'failed'));\\n        endTest(result ? 'PASS' : 'FAIL', 'Test completed with ' + (result ? 'success' : 'failures'));\\n    });\\n}",
+    "styles": "#test-elements ol { margin-left: 20px; line-height: 1.5; }"
+}

--- a/test_templates/TEST_002_input_validation/test.html
+++ b/test_templates/TEST_002_input_validation/test.html
@@ -1,0 +1,9 @@
+<div>
+    <p>This test verifies input field behavior:</p>
+    <ol>
+        <li>Check initial empty state</li>
+        <li>Populate input field</li>
+        <li>Verify visual appearance</li>
+    </ol>
+    <input type="text" id="test-input" placeholder="Input field">
+</div>

--- a/test_templates/TEST_002_input_validation/test.json
+++ b/test_templates/TEST_002_input_validation/test.json
@@ -1,0 +1,7 @@
+{
+    "name": "Input Field Validation Test",
+    "base_template": "grid.html",
+    "init": "var inputValue = '';",
+    "body": "const input = document.getElementById('test-input');\\nif (!input.value) {\\n    reportStep(1, 'PASS', 'Input field is empty');\\n    input.value = 'test123';\\n    setTimeout(runTest, 1000);\\n} else if (input.value === 'test123') {\\n    reportStep(2, 'PASS', 'Input field was populated');\\n    askManual('Can you see the text \"test123\" in the input field?').then(function(result) {\\n        reportStep(3, result ? 'PASS' : 'FAIL', 'Visual verification ' + (result ? 'succeeded' : 'failed'));\\n        endTest(result ? 'PASS' : 'FAIL', 'Test completed with ' + (result ? 'success' : 'failures'));\\n    });\\n}",
+    "styles": "#test-input { padding: 8px; border: 1px solid #ccc; border-radius: 4px; width: 200px; margin-top: 10px; }"
+}

--- a/test_templates/TEST_003_visual_check/test.html
+++ b/test_templates/TEST_003_visual_check/test.html
@@ -1,0 +1,13 @@
+<div>
+    <p>This test verifies the visibility and alignment of basic shapes:</p>
+    <div class="shapes-container">
+        <div class="shape circle"></div>
+        <div class="shape square"></div>
+    </div>
+    <p>The test will check:</p>
+    <ol>
+        <li>Red circle visibility</li>
+        <li>Blue square visibility</li>
+        <li>Shape alignment</li>
+    </ol>
+</div>

--- a/test_templates/TEST_003_visual_check/test.json
+++ b/test_templates/TEST_003_visual_check/test.json
@@ -1,0 +1,7 @@
+{
+    "name": "Visual Elements Check",
+    "base_template": "cards.html",
+    "init": "var checkCount = 0;",
+    "body": "checkCount++;\\nswitch(checkCount) {\\n    case 1:\\n        reportStep(1, 'PASS', 'Starting visual checks');\\n        setTimeout(runTest, 1000);\\n        break;\\n    case 2:\\n        askManual('Is the red circle visible?').then(function(result) {\\n            reportStep(2, result ? 'PASS' : 'FAIL', 'Red circle visibility ' + (result ? 'confirmed' : 'failed'));\\n            setTimeout(runTest, 1000);\\n        });\\n        break;\\n    case 3:\\n        askManual('Is the blue square visible?').then(function(result) {\\n            reportStep(3, result ? 'PASS' : 'FAIL', 'Blue square visibility ' + (result ? 'confirmed' : 'failed'));\\n            setTimeout(runTest, 1000);\\n        });\\n        break;\\n    case 4:\\n        askManual('Are both shapes properly aligned?').then(function(result) {\\n            reportStep(4, result ? 'PASS' : 'FAIL', 'Shape alignment ' + (result ? 'confirmed' : 'failed'));\\n            endTest(result ? 'PASS' : 'FAIL', 'Visual test completed with ' + (result ? 'success' : 'failures'));\\n        });\\n        break;\\n}",
+    "styles": ".shape { display: inline-block; margin: 10px; }\\n.circle { width: 50px; height: 50px; border-radius: 50%; background: red; }\\n.square { width: 50px; height: 50px; background: blue; }"
+}


### PR DESCRIPTION
This PR adds support for multiple base templates and includes responsive layouts:

- Added support for multiple base templates (grid.html and cards.html)
- Made layouts responsive and mobile-friendly
- Created three example test cases:
  1. TEST_001_step_sequence (grid layout)
  2. TEST_002_input_validation (grid layout)
  3. TEST_003_visual_check (card layout)
- Updated test generator to handle template selection
- Improved manual verification UI with overlay and better buttons

Test cases are live at:
https://jensk-dk.github.io/HtmlHbbTVTestCaseGenerator/